### PR TITLE
Feature/calendar deploy

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
     <link rel="preload" href="/assets/application.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <link rel="stylesheet" href="/assets/application.css" />
 
     <!-- CSSを読み込む（必要に応じて追加） -->
     <link rel="stylesheet" href="/toastui-calendar.min.css" />

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
   # Do not fall back to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
   config.assets.paths << Rails.root.join("app", "assets", "builds")
-  config.assets.precompile += %w(application.css)
+  config.assets.precompile += %w[application.css]
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,6 +29,8 @@ Rails.application.configure do
 
   # Do not fall back to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
+  config.assets.paths << Rails.root.join("app", "assets", "builds")
+  config.assets.precompile += %w(application.css)
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"


### PR DESCRIPTION
## 概要
本番環境でのデザイン（CSS）が表示されない問題に対応するため、アセットのプリコンパイル設定を修正。
## 変更点

このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

- `config/environments/production.rb に config.assets.paths と config.assets.precompile を追加`
- `RAILS_ENV=production bundle exec rails assets:precompile` を実行し、アセットを本番用にプリコンパイル

