### PR TITLE
本番環境用アセットのプリコンパイル

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
     <link rel="preload" href="/assets/application.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-    <%= stylesheet_link_tag "application", media: "all" %>
+    <%= stylesheet_link_tag "application", media: "all", "data-turbo-track" => "reload" %>
 
     <!-- CSSを読み込む（必要に応じて追加） -->
     <link rel="stylesheet" href="/toastui-calendar.min.css" />


### PR DESCRIPTION

## 変更点
CSSがpreloadとして読み込まれるが、実際にはstylesheet_link_tagで生成されたファイルとは一致しないため、Railsが生成したハッシュ付きファイル名を読み込んでいない。
-     <%= stylesheet_link_tag "application", media: "all", "data-turbo-track" => "reload" %>
