### PR TITLE
edamamのapiを辞め、楽天レシピで献立を作成し、openAIで栄養素を抽出

### DIFF
--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -9,131 +9,140 @@ class RecipesController < ApplicationController
 
   def create
     if params[:ingredients].present?
-      translated_ingredients = params[:ingredients].map do |ingredient|
-        translate_ingredient(ingredient)
-      end
-      query = translated_ingredients.reject(&:blank?).join(", ")
-
-      # 楽天レシピAPIでレシピ情報を取得
+      # 楽天API用に日本語のままキーワードを使用する
+      query = params[:ingredients].join(", ")
       @meal_plan = fetch_rakuten_recipe_details(query)
-
-      # Edamam APIで栄養素情報を取得
-      if @meal_plan && @meal_plan[:ingredients]
-        @nutrition_info = @meal_plan[:ingredients].each_with_object({}) do |ingredient, info|
-          # 重複しないようにingredientを適切にフォーマットする
-          cleaned_ingredient = ingredient.gsub(/(\d+\swhole\s)/, '').strip
-          info[ingredient] = fetch_nutrition(cleaned_ingredient)
-        end
+      
+      if @meal_plan.present? # ここで @meal_plan の有無を確認
+        Rails.logger.info("取得した@meal_planの内容: #{@meal_plan.inspect}")
+        
+        # 献立から食材リストを抽出
+        ingredients = @meal_plan[:ingredients] # ここで献立の食材リストを使用
+        # OpenAI APIで五大栄養素を取得
+        @nutrition_info = analyze_nutrition_with_openai(ingredients)
+      else
+        flash[:alert] = "該当するレシピが見つかりませんでした。別の食材をお試しください。"
+        render :new
+        return
       end
     else
+      flash[:alert] = "食材を入力してください。"
       render :new
       return
     end
-
+    
     render :show
   end
-
+  
   private
 
-  def fetch_recipe_image(ingredient)
-    # 仮にEdamam APIが画像URLを返すと仮定して処理
-    client = HTTPClient.new
-    app_id = ENV["EDAMAM_APP_ID"]
-    app_key = ENV["EDAMAM_APP_KEY"]
-    
-    # レシピ検索APIで食材に関連する画像を取得
-    response = client.get("https://api.edamam.com/api/recipes/v2", {
-      query: {
-        "app_id" => app_id,
-        "app_key" => app_key,
-        "q" => ingredient,
-        "type" => "public"
-      }
-    })
-  
-    # レスポンスをパース
-    data = JSON.parse(response.body)
-    
-    # 画像URLを取得（存在しない場合に備え、デフォルトURLも設定）
-    image_url = data.dig("hits", 0, "recipe", "image") || "/assets/default_recipe_image.png"
-    image_url
-  end
- 
-  def translate_ingredient(ingredient)
-    client = OpenAI::Client.new(access_token: ENV["OPENAI_API_KEY"])
-    response = client.chat(
-      parameters: {
-        model: "gpt-3.5-turbo",
-        messages: [{ role: "user", content: "Translate the following ingredient to English: #{ingredient}" }]
-      }
-    )
-    translated_ingredient = response["choices"].first["message"]["content"].strip
-    Rails.logger.info("Translated ingredient: #{translated_ingredient}")
-    translated_ingredient
-  end
-  
-
-  # **楽天レシピAPIでレシピIDを取得し、レシピの詳細情報を取得するメソッド**（新規追加）
-  # app/controllers/recipes_controller.rb
-
+  # 楽天レシピAPIからレシピ情報を取得するメソッド
   def fetch_rakuten_recipe_details(query)
     client = HTTPClient.new
     application_id = ENV["RAKUTEN_APP_ID"]
   
-    # カテゴリ別ランキングAPIでレシピIDと詳細情報を一度に取得
-    category_endpoint = "https://app.rakuten.co.jp/services/api/Recipe/CategoryRanking/20170426"
-    category_response = client.get(category_endpoint, {
+    # Step 1: 楽天カテゴリ一覧APIを使ってカテゴリを取得
+    category_response = client.get("https://app.rakuten.co.jp/services/api/Recipe/CategoryList/20170426", {
       query: {
         "applicationId" => application_id,
-        "keyword" => query,
         "format" => "json"
       }
     })
   
     category_data = JSON.parse(category_response.body)
+    Rails.logger.info("楽天レシピカテゴリAPIのレスポンス: #{category_data.inspect}")
   
-    # レシピが見つからなければnilを返す
-    recipe = category_data.dig("result", 0)
-    return unless recipe
+    # Step 2: キーワードを含むカテゴリを検索（部分一致を許可）
+    matching_category = category_data["result"]["large"].find do |category|
+      category["categoryName"].include?(query)
+    end
   
-    # 取得したデータから詳細情報を直接返す
+    # 中カテゴリや小カテゴリも部分一致で検索
+    matching_category ||= category_data["result"]["medium"].find { |category| category["categoryName"].include?(query) }
+    matching_category ||= category_data["result"]["small"].find { |category| category["categoryName"].include?(query) }
+  
+    # 該当するカテゴリが見つからない場合はnilを返す
+    unless matching_category
+      Rails.logger.info("キーワードに該当するカテゴリが見つかりませんでした")
+      flash[:alert] = "該当するカテゴリが見つかりませんでした。異なるキーワードをお試しください。"
+      return nil
+    end
+  
+    # 親カテゴリIDと結合してカテゴリIDを作成
+    category_id = if matching_category["parentCategoryId"]
+                    "#{matching_category["parentCategoryId"]}-#{matching_category["categoryId"]}"
+                  else
+                    matching_category["categoryId"]
+                  end
+  
+    # Step 3: 該当カテゴリIDでレシピを取得
+    recipe_response = client.get("https://app.rakuten.co.jp/services/api/Recipe/CategoryRanking/20170426", {
+      query: {
+        "applicationId" => application_id,
+        "categoryId" => category_id,
+        "format" => "json"
+      }
+    })
+  
+    recipe_data = JSON.parse(recipe_response.body)
+    Rails.logger.info("楽天レシピカテゴリ別ランキングAPIのレスポンス: #{recipe_data.inspect}")
+  
+    # レシピが存在するかを確認
+    if recipe_data["result"].present?
+      # ランダムでレシピを取得
+      matching_recipe = recipe_data["result"].sample
+      Rails.logger.info("取得したレシピ: #{matching_recipe.inspect}")
+    else
+      Rails.logger.info("カテゴリに該当するレシピが存在しませんでした")
+      flash[:alert] = "該当するカテゴリにレシピが見つかりませんでした。"
+      return nil
+    end
+  
+    return unless matching_recipe
+  
+    # レシピ詳細を返す
     {
-      title: recipe["recipeTitle"],
-      url: recipe["recipeUrl"],
-      image: recipe["foodImageUrl"],
-      ingredients: recipe["recipeMaterial"], # 材料リスト
-      steps: recipe["recipeIndication"]
+      title: matching_recipe["recipeTitle"],
+      url: matching_recipe["recipeUrl"],
+      image: matching_recipe["foodImageUrl"],
+      ingredients: matching_recipe["recipeMaterial"],
+      steps: matching_recipe["recipeIndication"]
     }
   end
   
-
-
-  # app/controllers/recipes_controller.rb
-
-  def fetch_nutrition(ingredient)
-    client = HTTPClient.new
-    app_id = ENV["EDAMAM_APP_ID"]
-    app_key = ENV["EDAMAM_APP_KEY"]
-    
-    endpoint = "https://api.edamam.com/api/nutrition-data"
-    response = client.get(endpoint, {
-      query: {
-        "app_id" => app_id,
-        "app_key" => app_key,
-        "ingr" => ingredient # 量を除外してリクエスト
-      }
-    })
-    
-    data = JSON.parse(response.body)
-    Rails.logger.info("Edamam APIの完全なレスポンス: #{data.inspect}")
-
-    if data["totalNutrients"].empty?
-       Rails.logger.warn("栄養データが取得できませんでした。食材が正しく認識されなかった可能性があります。")
-    end
-
-    data
-  end
   
+  # OpenAIを使用して食材の栄養情報を取得するメソッド
+  # OpenAIを使用して食材の栄養情報を取得するメソッド
+# OpenAIを使用して食材の栄養情報を取得するメソッド
+def analyze_nutrition_with_openai(ingredients)
+  client = OpenAI::Client.new(access_token: ENV["OPENAI_API_KEY"])
+  response = client.chat(
+    parameters: {
+      model: "gpt-3.5-turbo",
+      messages: [{ role: "user", content: "次の食材の栄養素について五大栄養素（炭水化物、脂質、タンパク質、ビタミン、ミネラル）の内容を教えてください: #{ingredients.join(', ')}" }]
+    }
+  )
 
+  # 取得した内容をテキストとして取り出し
+  nutrition_text = response["choices"].first["message"]["content"].strip
+  Rails.logger.info("OpenAIからの栄養素データ: #{nutrition_text}")
 
+  # 文字列を解析して構造化データに変換する処理
+  nutrition_info = {}
+  current_ingredient = nil
+  nutrition_text.lines.each do |line|
+    line.strip!
+    # 食材名の行（例: "天然舞茸："）
+    if line.match?(/：$/)
+      current_ingredient = line.sub(/：$/, '')
+      nutrition_info[current_ingredient] = {}
+    elsif current_ingredient && line.start_with?("- ")
+      # 栄養素情報の行（例: "- 炭水化物：ほとんど含まれていない"）
+      key, value = line.sub("- ", "").split("：", 2)
+      nutrition_info[current_ingredient][key] = value
+    end
+  end
+
+  nutrition_info
+end
 end

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -9,20 +9,25 @@ class RecipesController < ApplicationController
 
   def create
     if params[:ingredients].present?
-      # 食材をOpenAIで翻訳
-      translated_ingredients = params[:ingredients].map { |ingredient| translate_ingredient(ingredient) }
-      query = translated_ingredients.reject(&:blank?).join(",")
-      nutrients = params[:nutrients].is_a?(Array) ? params[:nutrients] : [ params[:nutrients] ]
-      # OpenAIで献立を生成
-      @meal_plan = generate_menu_with_openai(translated_ingredients, nutrients)
+      translated_ingredients = params[:ingredients].map do |ingredient|
+        translate_ingredient(ingredient)
+      end
+      query = translated_ingredients.reject(&:blank?).join(", ")
 
-      # Edamam APIで栄養情報を取得
-      @nutrition_info = translated_ingredients.each_with_object({}) do |ingredient, info|
-        info[ingredient] = fetch_nutrition(ingredient)
+      # 楽天レシピAPIでレシピ情報を取得
+      @meal_plan = fetch_rakuten_recipe_details(query)
+
+      # Edamam APIで栄養素情報を取得
+      if @meal_plan && @meal_plan[:ingredients]
+        @nutrition_info = @meal_plan[:ingredients].each_with_object({}) do |ingredient, info|
+          # 重複しないようにingredientを適切にフォーマットする
+          cleaned_ingredient = ingredient.gsub(/(\d+\swhole\s)/, '').strip
+          info[ingredient] = fetch_nutrition(cleaned_ingredient)
+        end
       end
     else
       render :new
-      return  # アクション終了
+      return
     end
 
     render :show
@@ -30,57 +35,105 @@ class RecipesController < ApplicationController
 
   private
 
-  # OpenAIを使って献立を生成するメソッド
-  def generate_menu_with_openai(ingredients, nutrients)
+  def fetch_recipe_image(ingredient)
+    # 仮にEdamam APIが画像URLを返すと仮定して処理
+    client = HTTPClient.new
+    app_id = ENV["EDAMAM_APP_ID"]
+    app_key = ENV["EDAMAM_APP_KEY"]
+    
+    # レシピ検索APIで食材に関連する画像を取得
+    response = client.get("https://api.edamam.com/api/recipes/v2", {
+      query: {
+        "app_id" => app_id,
+        "app_key" => app_key,
+        "q" => ingredient,
+        "type" => "public"
+      }
+    })
+  
+    # レスポンスをパース
+    data = JSON.parse(response.body)
+    
+    # 画像URLを取得（存在しない場合に備え、デフォルトURLも設定）
+    image_url = data.dig("hits", 0, "recipe", "image") || "/assets/default_recipe_image.png"
+    image_url
+  end
+ 
+  def translate_ingredient(ingredient)
     client = OpenAI::Client.new(access_token: ENV["OPENAI_API_KEY"])
-
-    # OpenAIに送る指示（プロンプト）
-    prompt = <<~TEXT
-      以下の食材と栄養素を考慮して、**完全に日本語で**バランスの良い1日分の朝・昼・晩の献立を提案してください。
-      食材: #{ingredients.join(", ")}
-      栄養素: #{nutrients.join(", ")}
-
-      各食事に簡単な調理手順も含めてください。
-    TEXT
-
     response = client.chat(
       parameters: {
         model: "gpt-3.5-turbo",
-        messages: [ { role: "user", content: prompt } ],
-        max_tokens: 500
+        messages: [{ role: "user", content: "Translate the following ingredient to English: #{ingredient}" }]
       }
     )
-
-    response["choices"].first["message"]["content"]
+    translated_ingredient = response["choices"].first["message"]["content"].strip
+    Rails.logger.info("Translated ingredient: #{translated_ingredient}")
+    translated_ingredient
   end
+  
 
-  # Edamam APIから栄養情報を取得するメソッド
+  # **楽天レシピAPIでレシピIDを取得し、レシピの詳細情報を取得するメソッド**（新規追加）
+  # app/controllers/recipes_controller.rb
+
+  def fetch_rakuten_recipe_details(query)
+    client = HTTPClient.new
+    application_id = ENV["RAKUTEN_APP_ID"]
+  
+    # カテゴリ別ランキングAPIでレシピIDと詳細情報を一度に取得
+    category_endpoint = "https://app.rakuten.co.jp/services/api/Recipe/CategoryRanking/20170426"
+    category_response = client.get(category_endpoint, {
+      query: {
+        "applicationId" => application_id,
+        "keyword" => query,
+        "format" => "json"
+      }
+    })
+  
+    category_data = JSON.parse(category_response.body)
+  
+    # レシピが見つからなければnilを返す
+    recipe = category_data.dig("result", 0)
+    return unless recipe
+  
+    # 取得したデータから詳細情報を直接返す
+    {
+      title: recipe["recipeTitle"],
+      url: recipe["recipeUrl"],
+      image: recipe["foodImageUrl"],
+      ingredients: recipe["recipeMaterial"], # 材料リスト
+      steps: recipe["recipeIndication"]
+    }
+  end
+  
+
+
+  # app/controllers/recipes_controller.rb
+
   def fetch_nutrition(ingredient)
     client = HTTPClient.new
     app_id = ENV["EDAMAM_APP_ID"]
     app_key = ENV["EDAMAM_APP_KEY"]
-
+    
     endpoint = "https://api.edamam.com/api/nutrition-data"
     response = client.get(endpoint, {
       query: {
         "app_id" => app_id,
         "app_key" => app_key,
-        "ingr" => ingredient
+        "ingr" => ingredient # 量を除外してリクエスト
       }
     })
+    
+    data = JSON.parse(response.body)
+    Rails.logger.info("Edamam APIの完全なレスポンス: #{data.inspect}")
 
-    JSON.parse(response.body)
-  end
+    if data["totalNutrients"].empty?
+       Rails.logger.warn("栄養データが取得できませんでした。食材が正しく認識されなかった可能性があります。")
+    end
 
-  # 食材の翻訳メソッド
-  def translate_ingredient(ingredient)
-    client = OpenAI::Client.new
-    response = client.chat(
-      parameters: {
-        model: "gpt-3.5-turbo",
-        messages: [ { role: "user", content: "Translate the following ingredient to English: #{ingredient}" } ]
-      }
-    )
-    response["choices"].first["message"]["content"].strip
+    data
   end
+  
+
+
 end

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -6,6 +6,7 @@
   <div class="max-w-4xl mx-auto bg-white rounded-lg shadow-md p-6">
     <!-- レシピタイトルと画像 -->
     <h2 class="text-2xl font-semibold mb-4"><%= @meal_plan[:title] %></h2>
+
     <div class="text-center mb-6">
       <img src="<%= @meal_plan[:image] %>" alt="レシピ画像" class="mx-auto rounded-lg shadow-lg">
     </div>
@@ -30,12 +31,17 @@
     <h2 class="text-2xl font-semibold mb-4">栄養情報</h2>
     <% if @nutrition_info.present? %>
       <ul class="space-y-4 mb-6">
-        <% @nutrition_info.each do |ingredient, data| %>
-          <% if data.dig("totalNutrients", "ENERC_KCAL", "quantity") %>
-            <p><strong><%= ingredient %></strong>: カロリー: <%= data.dig("totalNutrients", "ENERC_KCAL", "quantity") %> kcal</p>
-          <% else %>
-            <p><strong><%= ingredient %></strong>: 栄養情報が取得できませんでした。</p>
-          <% end %>
+        <% @nutrition_info.each do |ingredient, nutrients| %>
+          <li>
+            <strong><%= ingredient %></strong>
+            <ul class="list-disc list-inside ml-4">
+              <!-- ここから修正: 栄養情報のリスト表示を調整（行46-50） -->
+              <% nutrients.each do |nutrient, value| %>
+                <li><%= nutrient %>: <%= value %></li>
+              <% end %>
+              <!-- ここまで修正: 栄養情報のリスト表示を調整 -->
+            </ul>
+          </li>
         <% end %>
       </ul>
     <% else %>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -1,16 +1,52 @@
 <!-- app/views/recipes/show.html.erb -->
-<h1>生成された献立</h1>
 
-<p><%= @meal_plan %></p>
+<h1 class="text-3xl font-bold text-center mb-6">生成された献立</h1>
 
-<h2>栄養情報</h2>
-<ul>
-  <% @nutrition_info.each do |ingredient, data| %>
-    <li>
-      <strong><%= ingredient %></strong>: カロリー: <%= data["calories"] %> kcal, 
-      タンパク質: <%= data.dig("totalNutrients", "PROCNT", "quantity") %> g, 
-      脂質: <%= data.dig("totalNutrients", "FAT", "quantity") %> g, 
-      炭水化物: <%= data.dig("totalNutrients", "CHOCDF", "quantity") %> g
-    </li>
-  <% end %>
-</ul>
+<% if @meal_plan.present? %>
+  <div class="max-w-4xl mx-auto bg-white rounded-lg shadow-md p-6">
+    <!-- レシピタイトルと画像 -->
+    <h2 class="text-2xl font-semibold mb-4"><%= @meal_plan[:title] %></h2>
+    <div class="text-center mb-6">
+      <img src="<%= @meal_plan[:image] %>" alt="レシピ画像" class="mx-auto rounded-lg shadow-lg">
+    </div>
+
+    <!-- 材料 -->
+    <h3 class="text-xl font-semibold mb-2">材料</h3>
+    <ul class="list-disc list-inside mb-6 text-gray-700">
+      <% if @meal_plan[:ingredients].present? %>
+        <% @meal_plan[:ingredients].each do |ingredient| %>
+          <li><%= ingredient %></li>
+        <% end %>
+      <% else %>
+        <li>材料が取得できませんでした。</li>
+      <% end %>
+    </ul>
+
+    <!-- 手順 -->
+    <h3 class="text-xl font-semibold mb-2">手順</h3>
+    <p class="text-gray-700 mb-6"><%= @meal_plan[:steps] || "手順が取得できませんでした。" %></p>
+
+    <!-- 栄養情報 -->
+    <h2 class="text-2xl font-semibold mb-4">栄養情報</h2>
+    <% if @nutrition_info.present? %>
+      <ul class="space-y-4 mb-6">
+        <% @nutrition_info.each do |ingredient, data| %>
+          <% if data.dig("totalNutrients", "ENERC_KCAL", "quantity") %>
+            <p><strong><%= ingredient %></strong>: カロリー: <%= data.dig("totalNutrients", "ENERC_KCAL", "quantity") %> kcal</p>
+          <% else %>
+            <p><strong><%= ingredient %></strong>: 栄養情報が取得できませんでした。</p>
+          <% end %>
+        <% end %>
+      </ul>
+    <% else %>
+      <p>栄養情報が取得できませんでした。</p>
+    <% end %>
+
+    <!-- レシピへのリンク -->
+    <div class="text-center">
+      <a href="<%= @meal_plan[:url] %>" target="_blank" class="text-blue-500 underline">レシピの詳細を見る</a>
+    </div>
+  </div>
+<% else %>
+  <p>指定した食材に基づくレシピが見つかりませんでした。</p>
+<% end %>


### PR DESCRIPTION
## 概要

edamamのAPIから楽天レシピAPIに切り替え、献立の取得方法を変更しました。また、OpenAIを利用して栄養素の抽出を行うように実装を変更しています。このPRでは、それに伴う変更と調整が含まれていますが、栄養素が反映されないため、次回で実装予定。
## 変更点

- edamam API の利用を廃止し、楽天レシピAPIを使用して献立を取得
- OpenAI APIを使用して、取得したレシピから栄養素情報を抽出する機能を追加
- レシピ取得後に表示する栄養情報の処理ロジックを変更し、栄養素データをデバッグ表示から最終表示に反映

## 影響範囲

このセクションでは、このPRが影響を及ぼす範囲や他の機能への影響を説明してください。

## テスト

- 楽天レシピAPIからのレシピ取得テスト
正常なレシピデータが取得され、タイトル、画像、材料、手順が正しく表示されることを確認
- OpenAIによる栄養素抽出テスト
レシピデータから栄養素の取得ができないため、一旦プッシュ。
- 抽出データが不足する場合のエラーメッセージが表示されることを確認
## 関連Issue

このセクションでは、このPRが関連するIssueやタスクをリンクしてください。以下のように記述します。

- 関連Issue: #10
