### PR TITLE
Xへのシェア機能の追加

### DIFF
--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -38,6 +38,11 @@ class RecipesController < ApplicationController
   def show
     @calendar_plans = CalendarPlan.where(user: current_user, date: params[:id])
 
+    if @calendar_plans.present?
+      @share_text = generate_share_text
+      @share_url = request.base_url + recipe_path(params[:id])
+    end
+
     @parsed_meal_plans = @calendar_plans.map do |plan|
       begin
         meal_plan = JSON.parse(plan.meal_plan, symbolize_names: true)
@@ -64,6 +69,25 @@ class RecipesController < ApplicationController
   end
 
   private
+
+  def generate_share_text
+    plan = JSON.parse(@calendar_plans.first.meal_plan)
+    time_mapping = {
+      "morning" => "朝食",
+      "afternoon" => "昼食",
+      "evening" => "夕食"
+    }
+
+    meal_time = time_mapping[@calendar_plans.first.meal_time.downcase] || "食事"
+
+    text = "【#{meal_time}の献立】\n"
+    text += "主食：#{plan['main']}\n"
+    text += "主菜：#{plan['side']}\n"
+    text += "副菜：#{plan['salad']}\n"
+    text += "\n#パクラク #献立 #料理"
+
+    ERB::Util.url_encode(text)
+  end
 
   DEFAULT_NUTRIENTS = {
     protein: "0g",

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -15,9 +15,18 @@
         }, 
         class: "bg-blue-500 text-white py-2 px-4 rounded-lg shadow hover:bg-blue-600" %>
 
-    <button class="bg-green-500 text-white py-2 px-4 rounded-lg shadow hover:bg-green-600">
-      Xへ投稿
-    </button>
+    <% if @share_text.present? %>
+    <%= link_to "https://twitter.com/intent/tweet?text=#{@share_text}&url=#{@share_url}",
+      target: "_blank",
+      rel: "noopener noreferrer",
+      class: "inline-flex items-center bg-black text-white py-2 px-4 rounded-lg shadow hover:bg-gray-800 transition duration-200" do %>
+    <%# Xのアイコン %>
+    <svg class="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 24 24">
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+    Xへ投稿
+    <% end %>
+    <% end %>
   </div>
 
   <% if @calendar_plans.present? %>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,25 +1,21 @@
-# Be sure to restart your server when you modify this file.
+# config/initializers/content_security_policy.rb
 
-# Define an application-wide content security policy.
-# See the Securing Rails Applications Guide for more information:
-# https://guides.rubyonrails.org/security.html#content-security-policy-header
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    # 基本的なセキュリティポリシー
+    policy.default_src :self, :https
+    policy.font_src    :self, :https, :data
+    policy.img_src     :self, :https, :data
+    policy.object_src  :none
+    policy.script_src  :self, :https
+    policy.style_src   :self, :https
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src style-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+    # Xとの連携のために追加
+    policy.connect_src :self, :https, "https://twitter.com"
+    policy.frame_src   :self, :https, "https://twitter.com"
+  end
+
+  # 以下の設定はそのまま残します
+  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  config.content_security_policy_nonce_directives = %w[script-src style-src]
+end


### PR DESCRIPTION
## 概要
Xシェア機能を実装しました。献立の詳細画面から、生成された献立をXで簡単にシェアできるようになります。

## 変更点
- RecipesControllerにシェア用テキスト生成機能を追加
- 献立詳細画面にXシェアボタンを実装
- シェア用のセキュリティ設定を追加

## 影響範囲
- 献立詳細画面（show.html.erb）の表示
- X（Twitter）との連携機能

## テスト
- [x] 献立詳細画面でXシェアボタンが正しく表示される
- [x] シェアボタンクリックでXの投稿画面が新しいタブで開く
- [x] 投稿文に献立内容（主食、主菜、副菜）が正しく表示される
- [x] ハッシュタグ（#パクラク #献立 #料理）が正しく表示される
- [x] シェアURLが正しく設定される
