### PR TITLE
Xへのシェア機能の追加

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -2,20 +2,32 @@
 
 Rails.application.configure do
   config.content_security_policy do |policy|
-    # 基本的なセキュリティポリシー
     policy.default_src :self, :https
     policy.font_src    :self, :https, :data
     policy.img_src     :self, :https, :data
     policy.object_src  :none
-    policy.script_src  :self, :https
-    policy.style_src   :self, :https
 
-    # Xとの連携のために追加
+    # インラインスクリプトとスタイルを許可
+    policy.script_src  :self, :https, :unsafe_inline, :unsafe_eval
+    policy.style_src   :self, :https, :unsafe_inline
+
+    # Active Storageのための設定
+    policy.img_src     :self, :https, :data, :blob
+
+    # Xとの連携のための設定
     policy.connect_src :self, :https, "https://twitter.com"
     policy.frame_src   :self, :https, "https://twitter.com"
+
+    # Active Storageのための追加設定
+    if Rails.env.production?
+      # Renderのドメインを許可
+      host = "pakuraku-app.onrender.com"
+      policy.connect_src :self, :https, "https://#{host}", "wss://#{host}"
+      policy.img_src     :self, :https, :data, :blob, "https://#{host}"
+    end
   end
 
-  # 以下の設定はそのまま残します
+  # 既存の設定はそのまま残す
   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
   config.content_security_policy_nonce_directives = %w[script-src style-src]
 end


### PR DESCRIPTION
## 概要
Xシェア機能を実装しました。献立の詳細画面から、生成された献立をXで簡単にシェアできるようになります。

## 変更点
- RecipesControllerにシェア用テキスト生成機能を追加
- 献立詳細画面にXシェアボタンを実装
- シェア用のセキュリティ設定を追加

## 影響範囲
- 献立詳細画面（show.html.erb）の表示
- X（Twitter）との連携機能

## テスト
- [x] 献立詳細画面でXシェアボタンが正しく表示される
- [x] シェアボタンクリックでXの投稿画面が新しいタブで開く
- [x] 投稿文に献立内容（主食、主菜、副菜）が正しく表示される
- [x] ハッシュタグ（#パクラク #献立 #料理）が正しく表示される
- [x] シェアURLが正しく設定される
