### PR TITLE
ユーザーごとに表示

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -4,17 +4,15 @@ class StaticPagesController < ApplicationController
     @start_date = @date.beginning_of_month
     @end_date = @date.end_of_month
 
-    # ログインユーザーの場合は自分の献立のみ、未ログインの場合は公開された献立を表示
+    # ログインユーザーの場合のみ献立を表示
     @calendar_plans = if user_signed_in?
       current_user.calendar_plans
         .includes(:recipe)
         .where(date: @start_date..@end_date)
         .order(date: :asc, meal_time: :asc)
     else
-      CalendarPlan.includes(:recipe)
-        .publicly_visible  # スコープを使用
-        .where(date: @start_date..@end_date)
-        .order(date: :asc, meal_time: :asc)
+      # ゲストユーザーの場合は空の配列を返す
+      CalendarPlan.none
     end
 
     # 今日の献立を取得

--- a/app/models/calendar_plan.rb
+++ b/app/models/calendar_plan.rb
@@ -4,5 +4,4 @@ class CalendarPlan < ApplicationRecord
 
   validates :date, presence: true
   validates :meal_time, presence: true, inclusion: { in: [ "morning", "afternoon", "evening" ] }
-  scope :owned_by, ->(user) { where(user_id: user.id) }
 end

--- a/db/migrate/20250203135622_remove_public_from_calendar_plans.rb
+++ b/db/migrate/20250203135622_remove_public_from_calendar_plans.rb
@@ -1,0 +1,5 @@
+class RemovePublicFromCalendarPlans < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :calendar_plans, :public, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_03_132435) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_03_135622) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -50,8 +50,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_03_132435) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "meal_plan"
-    t.boolean "public", default: false, null: false
-    t.index ["public"], name: "index_calendar_plans_on_public"
     t.index ["recipe_id"], name: "index_calendar_plans_on_recipe_id"
     t.index ["user_id"], name: "index_calendar_plans_on_user_id"
   end


### PR DESCRIPTION
## 概要
ユーザーのプライバシー保護のため、`public`カラムを削除し、ログインユーザーのみが自分の献立を閲覧できるように修正しました。

## 変更点
1. `StaticPagesController`の修正
  - ゲストユーザーには献立を表示しないように変更
  - `publicly_visible`スコープの使用を削除

2. データベース変更
  - `calendar_plans`テーブルから不要な`public`カラムを削除

## 影響範囲
- 認証関連の処理
- 献立の表示制御
- データベース構造

## テスト項目
- [ ] ログインユーザーが自分の献立のみを閲覧できることを確認
- [ ] 他のユーザーの献立が表示されないことを確認
- [ ] ゲストユーザーに献立が表示されないことを確認
- [ ] マイグレーションが正常に実行されることを確認