### PR TITLE
gem-rack-cors追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem "high_voltage"
 gem "meta-tags"
 gem "omniauth-google-oauth2"
 gem "omniauth-rails_csrf_protection"
+gem "rack-cors"
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,6 +258,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.1.8)
+    rack-cors (2.0.2)
+      rack (>= 2.0.0)
     rack-protection (4.1.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)
@@ -432,6 +434,7 @@ DEPENDENCIES
   pg (~> 1.1)
   propshaft
   puma (>= 5.0)
+  rack-cors
   rails (~> 8.0.1)
   rails-i18n
   rubocop-rails-omakase

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -104,4 +104,15 @@ Rails.application.configure do
   #
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+
+  # CORS設定を追加
+  config.middleware.insert_before 0, Rack::Cors do
+    allow do
+      origins "https://eyemeshi.com", "https://pakuraku-app.onrender.com", "https://www.eyemeshi.com"
+      resource "*",
+               headers: :any,
+               methods: [ :get, :post, :put, :patch, :delete, :options, :head ],
+               credentials: true
+    end
+  end
 end


### PR DESCRIPTION
```
  # CORS設定を追加
  config.middleware.insert_before 0, Rack::Cors do
    allow do
      origins "https://eyemeshi.com", "https://pakuraku-app.onrender.com", "https://www.eyemeshi.com"
      resource "*",
               headers: :any,
               methods: [ :get, :post, :put, :patch, :delete, :options, :head ],
               credentials: true
    end
  end
```