### PR TITLE
パスワードリセットの機能追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,8 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+
+  gem "letter_opener_web"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    childprocess (5.1.0)
+      logger (~> 1.5)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
     crass (1.0.6)
@@ -164,6 +166,17 @@ GEM
       thor (~> 1.3)
       zeitwerk (>= 2.6.18, < 3.0)
     language_server-protocol (3.17.0.3)
+    launchy (3.1.0)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (3.0.0)
+      actionmailer (>= 6.1)
+      letter_opener (~> 1.9)
+      railties (>= 6.1)
+      rexml
     logger (1.6.5)
     loofah (2.24.0)
       crass (~> 1.0.2)
@@ -428,6 +441,7 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   kamal
+  letter_opener_web
   meta-tags
   omniauth-google-oauth2
   omniauth-rails_csrf_protection

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,8 @@
-<p>Hello <%= @resource.email %>!</p>
+<p>こんにちは、<%= @resource.email %>様</p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p>パスワードの再設定を受け付けました。以下のリンクからパスワードの再設定が可能です。</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to 'パスワードを再設定する', edit_password_url(@resource, reset_password_token: @token) %></p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p>このメールに心当たりがない場合は、このメールを無視してください。</p>
+<p>上記のリンクにアクセスして新しいパスワードを設定するまで、パスワードは変更されません。</p>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,39 @@
-<h2>Change your password</h2>
+<div class="min-h-screen flex flex-col items-center justify-center p-4 bg-gray-50">
+  <div class="w-full max-w-md bg-white rounded-lg shadow-md p-8">
+    <h2 class="text-2xl font-bold text-center text-gray-800 mb-6">パスワードの変更</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: "space-y-6" }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
+    <%= f.hidden_field :reset_password_token %>
 
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+    <div class="space-y-2">
+      <%= f.label :password, "新しいパスワード", class: "block text-sm font-medium text-gray-700" %>
+      <% if @minimum_password_length %>
+      <p class="text-sm text-gray-500">
+        （<%= @minimum_password_length %>文字以上必要です）
+      </p>
+      <% end %>
+      <%= f.password_field :password, 
+            autofocus: true, 
+            autocomplete: "new-password",
+            class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" %>
+    </div>
+
+    <div class="space-y-2">
+      <%= f.label :password_confirmation, "新しいパスワード（確認）", class: "block text-sm font-medium text-gray-700" %>
+      <%= f.password_field :password_confirmation, 
+            autocomplete: "new-password",
+            class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" %>
+    </div>
+
+    <div class="pt-4">
+      <%= f.submit "パスワードを変更する", 
+            class: "w-full px-4 py-2 text-white bg-indigo-600 hover:bg-indigo-700 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-colors duration-200" %>
+    </div>
     <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
-  </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+    <div class="mt-6 text-center text-sm text-gray-600">
+      <%= render "devise/shared/links" %>
+    </div>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,26 @@
-<h2>Forgot your password?</h2>
+<div class="min-h-screen flex flex-col items-center justify-center p-4">
+  <div class="w-full max-w-md bg-white rounded-lg shadow-md p-8">
+    <h2 class="text-2xl font-bold text-center mb-8">パスワードの再設定</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: "space-y-6" }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <div class="space-y-2">
+      <%= f.label :email, "メールアドレス", class: "block text-sm font-medium text-gray-700" %>
+      <%= f.email_field :email, 
+            autofocus: true, 
+            autocomplete: "email", 
+            class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" %>
+    </div>
+
+    <div class="pt-4">
+      <%= f.submit "パスワード再設定メールを送信", 
+            class: "w-full px-4 py-2 text-white bg-indigo-600 hover:bg-indigo-700 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-colors duration-200" %>
+    </div>
+    <% end %>
+
+    <div class="mt-6 text-center text-sm text-gray-600">
+      <%= render "devise/shared/links" %>
+    </div>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,7 +45,7 @@ Rails.application.configure do
   # config.assets.prefix = "/dev-assets"
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   # Make template changes take effect immediately.
   config.action_mailer.perform_caching = false
@@ -53,6 +53,20 @@ Rails.application.configure do
   # Set localhost to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
+  config.action_mailer.delivery_method = :letter_opener_web
+
+  config.action_mailer.perform_deliveries = true
+
+  # Gmail用のSMTP設定
+  # config.action_mailer.smtp_settings = {
+  #   address: 'smtp.gmail.com',
+  #   port: 587,
+  #   domain: 'localhost',
+  #   user_name: ENV['MAILER_SENDER'],
+  #   password: ENV['MAILER_PASSWORD'],
+  #   authentication: 'plain',
+  #   enable_starttls_auto: true
+  # }
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,6 +41,20 @@ Rails.application.configure do
     host: "eyemeshi.com",
     protocol: "https"
   }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.perform_caching = false
+  config.action_mailer.raise_delivery_errors = true
+
+  # Gmail用のSMTP設定を追加
+  config.action_mailer.smtp_settings = {
+    address: "smtp.gmail.com",
+    port: 587,
+    domain: "eyemeshi.com",  # あなたの本番環境のドメイン
+    user_name: ENV["MAILER_SENDER"],
+    password: ENV["MAILER_PASSWORD"],
+    authentication: "plain",
+    enable_starttls_auto: true
+  }
   # Active Storageのルーティング設定
   config.active_storage.resolve_model_to_route = :rails_storage_proxy
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
+  config.mailer_sender = ENV["MAILER_SENDER"]
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,8 @@ Rails.application.routes.draw do
   devise_for :users, controllers: {
     registrations: "users/registrations",
     sessions: "users/sessions",
-    omniauth_callbacks: "users/omniauth_callbacks"
+    omniauth_callbacks: "users/omniauth_callbacks",
+    passwords: "users/passwords"
   }
   root "static_pages#top"
 
@@ -11,4 +12,8 @@ Rails.application.routes.draw do
   resources :calendar_plans, only: [ :destroy ]
   resource :nutrition, only: [ :show ]
   resources :calendar_plans, only: [ :destroy, :edit, :update ]
+
+  if Rails.env.development?
+    mount LetterOpenerWeb::Engine, at: "/letter_opener"
+  end
 end


### PR DESCRIPTION
# パスワードリセット機能の実装

## 概要
* パスワードを忘れた場合のリセット機能を実装し、開発環境と本番環境での動作をしました
* メール送信機能を実装し、開発環境ではletter_opener_webを使用してブラウザでメールを確認できるようにしました
* ユーザー体験を向上させるため、関連する画面とメールの内容を日本語化しました

## 変更点
* メール送信機能の実装
  - 開発環境：letter_opener_webによるメールプレビュー機能の追加
  - 本番環境：Gmail SMTPサーバーを使用した実メール送信の設定
  - 環境変数（MAILER_SENDER, MAILER_PASSWORD）の設定

* ビュー関連の修正
  - パスワードリセットメールテンプレートの日本語化と改善（app\views\devise\passwords\new.html.erb、app\views\devise\passwords\edit.html.erb）
  - パスワード変更フォームのデザイン改善

## 影響範囲
* 設定ファイル
  - development.rbのメール設定
  - production.rbのメール設定
* ビューファイル
  - パスワードリセット関連のテンプレート
  - メール送信テンプレート

## テスト
* 開発環境でのテスト
  - letter_opener_webでのメール送信確認
  - パスワードリセットフローの動作確認
* 本番環境でのテスト
  - メール送信機能の確認
  - パスワードリセットリンクの有効性確認

## 関連するファイル
* config/environments/development.rb
* config/environments/production.rb
* app/views/devise/mailer/reset_password_instructions.html.erb
* app/views/devise/passwords/edit.html.erb
* config/routes.rb