### PR TITLE
主菜と副菜別の生成

### DIFF
--- a/app/services/recipe_service.rb
+++ b/app/services/recipe_service.rb
@@ -6,11 +6,15 @@ class RecipeService
     @user = user
   end
 
-  def create_meal_plans(selected_dates, nutrients)
+  def create_meal_plans(selected_dates, main_nutrients, side_nutrients = nil)
+    if main_nutrients.empty?
+      raise ValidationError.new("主菜の栄養素を一つ以上選択してください")
+    end
+
     plans = []
     selected_dates.each do |date, meal_times|
       meal_times.each do |meal_time|
-        meal_plan = generate_meal_plan(nutrients, meal_time)
+        meal_plan = generate_meal_plan(main_nutrients, side_nutrients, meal_time)
         if meal_plan
           calendar_plan = save_meal_plan(meal_plan, date, meal_time)
           plans << calendar_plan if calendar_plan
@@ -23,9 +27,17 @@ class RecipeService
   private
 
 
-  def create_prompt(nutrients, meal_time)
+  def create_prompt(main_nutrients, side_nutrients, meal_time)
     <<~PROMPT
       #{meal_time_to_japanese(meal_time)}の献立を提案してください。
+
+      【主菜の要件】
+      ・重点的に取り入れる栄養素: #{main_nutrients.join('、')}
+      #{format_nutrient_requirements(main_nutrients)}
+
+      【副菜の要件】
+      #{side_nutrients.present? ? "・重点的に取り入れる栄養素: #{side_nutrients.join('、')}" : "・主菜の栄養バランスを補完する栄養素を使用"}
+      #{format_nutrient_requirements(side_nutrients) if side_nutrients.present?}
 
       【重要：栄養価の計算手順】
       1. 主食の栄養価（特に注意が必要）：
@@ -72,61 +84,83 @@ class RecipeService
     PROMPT
   end
 
-def generate_meal_plan(nutrients, meal_time)
-  max_attempts = 5  # 最大5回まで試行します
-  attempts = 0
+  def format_nutrient_requirements(nutrients)
+    return "" unless nutrients.present?
 
-  while attempts < max_attempts
-    # 過去2週間の献立を取得
-    recent_meals = CalendarPlan.where(
-      user: @user,
-      created_at: 2.weeks.ago..Time.current
-    ).map { |plan| JSON.parse(plan.meal_plan) }
-
-    # 料理のジャンル選択
-    cuisine_types = [ "洋食", "和食", "中華" ]
-    last_cuisine = recent_meals.first&.dig("cuisine_type")
-    available_cuisines = cuisine_types - [ last_cuisine ].compact
-    selected_cuisine = available_cuisines.sample || cuisine_types.sample
-
-    # OpenAI APIで献立を生成
-    openai_client = OpenAI::Client.new(access_token: ENV["OPENAI_API_KEY"])
-    system_message = "あなたは料理のプロフェッショナルとして、栄養バランスがよく、調理時間の短い献立を提案してください。"
-    user_message = create_prompt(nutrients, meal_time)
-
-    begin
-      response = openai_client.chat(
-        parameters: {
-          model: "gpt-3.5-turbo",
-          messages: [
-            { role: "system", content: system_message },
-            { role: "user", content: user_message }
-          ],
-          temperature: 1.0,
-          max_tokens: 500
-        }
-      )
-
-      result = response.dig("choices", 0, "message", "content")
-      Rails.logger.info("API Response: #{result}")
-
-      if result.present?
-        parsed_result = JSON.parse(result, symbolize_names: true)
-        if valid_meal_plan?(parsed_result) && !duplicate_meal?(parsed_result, recent_meals)
-          return parsed_result  # 有効な献立が見つかったら返す
-        end
-        # 重複または無効な場合は再試行
-        Rails.logger.info("献立が重複または無効なため再生成します（#{attempts + 1}回目）")
+    requirements = nutrients.map do |nutrient|
+      case nutrient
+      when "タンパク質"
+        "・タンパク質が豊富な食材を使用（目安：15-25g）"
+      when "脂質"
+        "・適度な脂質を含む調理法（目安：10-15g）"
+      when "炭水化物"
+        "・適度な炭水化物を含む食材選択（目安：20-30g）"
+      when "ビタミン"
+        "・ビタミン類が豊富な野菜を使用"
+      when "ミネラル"
+        "・ミネラルを含む食材を積極的に使用"
       end
-    rescue => e
-      Rails.logger.error("エラーが発生しました: #{e.message}")
     end
 
-    attempts += 1  # 試行回数を増やす
+    requirements.join("\n")
   end
 
-  nil  # 最大試行回数を超えた場合はnilを返す
-end
+  def generate_meal_plan(main_nutrients, side_nutrients, meal_time)
+    max_attempts = 5  # 最大5回まで試行します
+    attempts = 0
+
+    while attempts < max_attempts
+      # 過去2週間の献立を取得
+      recent_meals = CalendarPlan.where(
+        user: @user,
+        created_at: 2.weeks.ago..Time.current
+      ).map { |plan| JSON.parse(plan.meal_plan) }
+
+      # 料理のジャンル選択
+      cuisine_types = [ "洋食", "和食", "中華" ]
+      last_cuisine = recent_meals.first&.dig("cuisine_type")
+      available_cuisines = cuisine_types - [ last_cuisine ].compact
+      selected_cuisine = available_cuisines.sample || cuisine_types.sample
+
+      # OpenAI APIで献立を生成
+      openai_client = OpenAI::Client.new(access_token: ENV["OPENAI_API_KEY"])
+      system_message = "あなたは料理のプロフェッショナルとして、指定された栄養素を考慮しながら、主菜と副菜のバランスの取れた献立を提案してください。"
+      user_message = create_prompt(main_nutrients, side_nutrients, meal_time)
+
+      begin
+        response = openai_client.chat(
+          parameters: {
+            model: "gpt-3.5-turbo",
+            messages: [
+              { role: "system", content: system_message },
+              { role: "user", content: user_message }
+            ],
+            temperature: 1.0,
+            max_tokens: 500
+          }
+        )
+
+        result = response.dig("choices", 0, "message", "content")
+        Rails.logger.info("API Response: #{result}")
+
+        if result.present?
+          parsed_result = JSON.parse(result, symbolize_names: true)
+          if valid_meal_plan?(parsed_result) && !duplicate_meal?(parsed_result, recent_meals)
+            return parsed_result  # 有効な献立が見つかったら返す
+          end
+          # 重複または無効な場合は再試行
+          Rails.logger.info("献立が重複または無効なため再生成します（#{attempts + 1}回目）")
+        end
+      rescue => e
+        Rails.logger.error("エラーが発生しました: #{e.message}")
+      end
+
+      attempts += 1  # 試行回数を増やす
+    end
+
+    nil  # 最大試行回数を超えた場合はnilを返す
+  end
+
   def valid_meal_plan?(plan)
     # まず基本的な構造チェック
     return false unless plan.is_a?(Hash)

--- a/app/views/recipes/new.html.erb
+++ b/app/views/recipes/new.html.erb
@@ -134,32 +134,59 @@
       </div>
     </div>
 
-    <%# 栄養素選択セクション - 変更なし %>
+    <%# 栄養素選択セクション %>
     <div class="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
       <div class="p-4 sm:p-6">
-        <h2 class="text-lg sm:text-xl font-bold text-gray-900 mb-4 sm:mb-6">栄養素を選択 (最大5つ)</h2>
-        <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-2 sm:gap-3">
-          <% ["ミネラル", "たんぱく質", "炭水化物", "ビタミン", "脂質"].each do |nutrient| %>
-          <div class="form-check flex items-center bg-white p-2 sm:p-3 rounded-lg border border-gray-200 hover:border-blue-300 transition-colors">
-            <%= check_box_tag "nutrients[]", 
-                          nutrient, 
-                          false, 
-                          id: "nutrient_#{nutrient}", 
-                          class: "form-check-input w-4 h-4 sm:w-5 sm:h-5" %>
-            <%= label_tag "nutrient_#{nutrient}", 
-                          nutrient, 
-                          class: "ml-2 text-xs sm:text-sm cursor-pointer flex-grow" %>
+        <h2 class="text-lg sm:text-xl font-bold text-gray-900 mb-4 sm:mb-6">栄養素を選択</h2>
+
+        <%# 主菜の栄養素選択 %>
+        <div class="mb-6">
+          <h3 class="text-base font-semibold text-gray-800 mb-3">主菜の栄養素（必須）</h3>
+          <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-2 sm:gap-3">
+            <% ["ミネラル", "たんぱく質", "炭水化物", "ビタミン", "脂質"].each do |nutrient| %>
+            <div class="form-check flex items-center bg-white p-2 sm:p-3 rounded-lg border border-gray-200 hover:border-blue-300 transition-colors">
+              <%= check_box_tag "main_nutrients[]", 
+                            nutrient, 
+                            false, 
+                            id: "main_nutrient_#{nutrient}", 
+                            class: "form-check-input w-4 h-4 sm:w-5 sm:h-5" %>
+              <%= label_tag "main_nutrient_#{nutrient}", 
+                         nutrient, 
+                         class: "ml-2 text-xs sm:text-sm cursor-pointer flex-grow" %>
+            </div>
+            <% end %>
           </div>
-          <% end %>
         </div>
 
-        <%# 送信ボタン %>
-        <div class="mt-6 sm:mt-8 flex justify-center">
-          <%= form.submit '献立を生成する', 
-                    class: 'w-full sm:w-auto inline-flex items-center justify-center px-4 sm:px-6 py-2 sm:py-3 border border-transparent text-sm sm:text-base font-medium rounded-lg shadow-sm text-white bg-orange-600 hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500 transition-colors duration-150' %>
+        <%# 副菜の栄養素選択 %>
+        <div class="mb-6">
+          <h3 class="text-base font-semibold text-gray-800 mb-3">副菜の栄養素（任意）</h3>
+          <p class="text-sm text-gray-600 mb-3">選択しない場合、主菜の栄養バランスを考慮して自動的に決定されます</p>
+          <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-2 sm:gap-3">
+            <% ["ミネラル", "たんぱく質", "炭水化物", "ビタミン", "脂質"].each do |nutrient| %>
+            <div class="form-check flex items-center bg-white p-2 sm:p-3 rounded-lg border border-gray-200 hover:border-blue-300 transition-colors">
+              <%= check_box_tag "side_nutrients[]", 
+                            nutrient, 
+                            false, 
+                            id: "side_nutrient_#{nutrient}", 
+                            class: "form-check-input w-4 h-4 sm:w-5 sm:h-5" %>
+              <%= label_tag "side_nutrient_#{nutrient}", 
+                         nutrient, 
+                         class: "ml-2 text-xs sm:text-sm cursor-pointer flex-grow" %>
+            </div>
+            <% end %>
+          </div>
         </div>
       </div>
     </div>
-    <% end %>
+
+    <%# 送信ボタン %>
+    <div class="mt-6 sm:mt-8 flex justify-center">
+      <%= form.submit '献立を生成する', 
+                    class: 'w-full sm:w-auto inline-flex items-center justify-center px-4 sm:px-6 py-2 sm:py-3 border border-transparent text-sm sm:text-base font-medium rounded-lg shadow-sm text-white bg-orange-600 hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500 transition-colors duration-150' %>
+    </div>
   </div>
+</div>
+<% end %>
+</div>
 </div>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -34,7 +34,8 @@
           selected_dates: { 
             @calendar_plans.first&.date&.strftime('%Y-%m-%d') => @calendar_plans.pluck(:meal_time) 
           }.compact,
-          nutrients: [] 
+          main_nutrients: session[:main_nutrients],
+          side_nutrients: session[:side_nutrients]
         },
         class: "inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition-colors" do %>
     <svg class="w-5 h-5 mr-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">


### PR DESCRIPTION
# 主菜・副菜別の栄養素選択による献立生成機能の追加

## 変更の概要
栄養素の選択を主菜と副菜で分けることで、より細かな献立のカスタマイズを可能にしました。これにより、ユーザーは主菜と副菜それぞれに異なる栄養素を指定できるようになります。

## 主な変更点
1. コントローラーの修正
- RecipesControllerのcreateアクションで主菜・副菜の栄養素を個別に処理
- バリデーションを追加（主菜の栄養素は必須）

2. サービスの修正
- RecipeServiceのcreate_meal_plansメソッドで主菜・副菜の栄養素を考慮
- 献立生成のプロンプトを更新

3. ビューの更新
- 栄養素選択フォームを主菜・副菜で分割
- UIの改善と説明文の追加

## テストケース
1. 主菜のみ栄養素を選択した場合
- 主菜：タンパク質を選択
- 副菜：選択なし
→ 副菜は主菜の栄養バランスを補完する形で生成される

2. 主菜・副菜両方の栄養素を選択した場合
- 主菜：タンパク質、脂質を選択
- 副菜：ビタミン、ミネラルを選択
→ それぞれ指定された栄養素を考慮して生成される

3. バリデーション確認
- 主菜の栄養素が未選択の場合はエラーメッセージを表示

## 変更内容の詳細

### コントローラーの変更
```ruby
# app/controllers/recipes_controller.rb
def create
  selected_dates = params[:selected_dates] || {}
  main_nutrients = params[:main_nutrients] || []
  side_nutrients = params[:side_nutrients] || []

  if selected_dates.empty?
    redirect_to new_recipe_path, alert: "日付を選択してください" and return
  end

  if main_nutrients.empty?
    redirect_to new_recipe_path, alert: "主菜の栄養素を1つ以上選択してください" and return
  end

  recipe_service = RecipeService.new(current_user)
  calendar_plans = recipe_service.create_meal_plans(
    selected_dates,
    main_nutrients,
    side_nutrients
  )
  ...
end