### PR TITLE
recipe/modelのcatagoryカラムを追加し和風、中華、洋風別に献立生成追加

### DIFF
--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -14,6 +14,7 @@ class RecipesController < ApplicationController
     selected_dates = params[:selected_dates] || {}
     main_nutrients = params[:main_nutrients] || []
     side_nutrients = params[:side_nutrients] || []
+    category = params[:category]
 
     # パラメータのバリデーション
     if selected_dates.empty?
@@ -26,6 +27,7 @@ class RecipesController < ApplicationController
 
     session[:main_nutrients] = main_nutrients
     session[:side_nutrients] = side_nutrients
+    session[:category] = category
 
     recipe_service = RecipeService.new(current_user)
 
@@ -33,7 +35,8 @@ class RecipesController < ApplicationController
       calendar_plans = recipe_service.create_meal_plans(
         selected_dates,
         main_nutrients,
-        side_nutrients
+        side_nutrients,
+        category
       )
 
       if calendar_plans.present?

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -3,4 +3,10 @@ class Recipe < ApplicationRecord
 
   has_many :foods, dependent: :destroy
   has_many :calendar_plans, dependent: :destroy
+
+  CATEGORIES = {
+    japanese: "和食",
+    chinese: "中華",
+    western: "洋食"
+  }.freeze
 end

--- a/app/views/recipes/new.html.erb
+++ b/app/views/recipes/new.html.erb
@@ -134,6 +134,29 @@
       </div>
     </div>
 
+    <%# カテゴリー選択セクション %>
+    <div class="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
+      <div class="p-4 sm:p-6">
+        <h2 class="text-lg sm:text-xl font-bold text-gray-900 mb-4 sm:mb-6">料理のカテゴリー（任意）</h2>
+        <p class="text-sm text-gray-600 mb-3">選択しない場合、バランスの良い組み合わせで自動的に決定されます</p>
+
+        <div class="grid grid-cols-2 sm:grid-cols-3 gap-2 sm:gap-3">
+          <% Recipe::CATEGORIES.each do |key, value| %>
+          <div class="form-check flex items-center bg-white p-2 sm:p-3 rounded-lg border border-gray-200 hover:border-blue-300 transition-colors">
+            <%= radio_button_tag "category", 
+                          key, 
+                          false, 
+                          id: "category_#{key}", 
+                          class: "form-check-input w-4 h-4 sm:w-5 sm:h-5" %>
+            <%= label_tag "category_#{key}", 
+                       value, 
+                       class: "ml-2 text-xs sm:text-sm cursor-pointer flex-grow" %>
+          </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+
     <%# 栄養素選択セクション %>
     <div class="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
       <div class="p-4 sm:p-6">

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -35,7 +35,8 @@
             @calendar_plans.first&.date&.strftime('%Y-%m-%d') => @calendar_plans.pluck(:meal_time) 
           }.compact,
           main_nutrients: session[:main_nutrients],
-          side_nutrients: session[:side_nutrients]
+          side_nutrients: session[:side_nutrients],
+          category: session[:category]
         },
         class: "inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition-colors" do %>
     <svg class="w-5 h-5 mr-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">

--- a/db/migrate/20250211064739_add_category_to_recipes.rb
+++ b/db/migrate/20250211064739_add_category_to_recipes.rb
@@ -1,0 +1,5 @@
+class AddCategoryToRecipes < ActiveRecord::Migration[8.0]
+  def change
+    add_column :recipes, :category, :string
+  end
+end

--- a/db/migrate/20250211064911_add_index_to_category_in_recipes.rb
+++ b/db/migrate/20250211064911_add_index_to_category_in_recipes.rb
@@ -1,0 +1,5 @@
+class AddIndexToCategoryInRecipes < ActiveRecord::Migration[8.0]
+  def change
+    add_index :recipes, :category
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_04_134530) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_11_064911) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -102,6 +102,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_04_134530) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "category"
+    t.index ["category"], name: "index_recipes_on_category"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
# 料理カテゴリー（和食・中華・洋食）選択機能の追加
## 概要
献立生成時に料理のカテゴリー（和食・中華・洋食）を選択できる機能を追加しました。カテゴリーは任意選択とし、選択しない場合は従来通りランダムに料理のジャンルが決定されます。
## 変更内容
Recipeモデルにカテゴリーカラムを追加（japanese, chinese, western）
カテゴリー選択用のUIをフォームに追加
選択されたカテゴリーに基づいて献立を生成するようRecipeServiceを修正
生成された献立のカテゴリー情報をデータベースに保存する機能を追加

## テスト
 カテゴリー選択UIの表示確認
 各カテゴリー（和食・中華・洋食）選択時の献立生成確認
 カテゴリー未選択時の動作確認
 データベースへのカテゴリー情報保存確認

## 関連Issue
#147 