### PR TITLE
複数献立時の改善

### DIFF
--- a/app/views/recipes/new.html.erb
+++ b/app/views/recipes/new.html.erb
@@ -103,30 +103,30 @@ app\views\recipes\new.html.erb
                       <% time_plans.each do |plan| %>
                       <% begin %>
                       <% meal_data = JSON.parse(plan.meal_plan) %>
-                      <div class="group relative p-1 rounded-lg hover:bg-orange-50 transition-colors">
+                      <div class="relative group">
+                        <%= link_to recipe_path(id: plan.date, from_calendar: true), class: "block p-1 rounded-lg hover:bg-orange-50 transition-colors" do %>
                         <div class="flex items-start gap-1">
                           <span class="inline-block w-5 text-center px-0.5 text-xs font-medium bg-emerald-100 text-emerald-700 rounded">主</span>
                           <span class="text-xs text-gray-600 truncate"><%= meal_data["main"] %></span>
-
-                          <%# 削除ボタン部分を以下のように変更 %>
-                          <% if current_user.present? && plan.user_id == current_user.id %>
-                          <%= link_to calendar_plan_path(plan),
-              data: {
-                turbo_method: :delete,
-                turbo_confirm: "この献立を削除してもよろしいですか？"
-              },
-              class: "absolute right-1 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 p-1 rounded-full hover:bg-red-50 transition-all" do %>
-                          <svg class="w-3.5 h-3.5 text-red-400 hover:text-red-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path d="M3 6h18M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2M10 11v6M14 11v6" />
-                          </svg>
-                          <% end %>
-                          <% end %>
-
                         </div>
                         <div class="flex items-start gap-1 mt-0.5">
                           <span class="inline-block w-5 text-center px-0.5 text-xs font-medium bg-amber-100 text-amber-700 rounded">副</span>
                           <span class="text-xs text-gray-600 truncate"><%= meal_data["side"] %></span>
                         </div>
+                        <% end %>
+                        <%# 削除ボタン %>
+                        <% if current_user.present? && plan.user_id == current_user.id %>
+                        <%= link_to calendar_plan_path(plan),
+                            data: {
+                              turbo_method: :delete,
+                              turbo_confirm: "この献立を削除してもよろしいですか？"
+                            },
+                            class: "absolute right-1 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 p-1 rounded-full hover:bg-red-50 transition-all" do %>
+                        <svg class="w-3.5 h-3.5 text-red-400 hover:text-red-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                          <path d="M3 6h18M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2M10 11v6M14 11v6" />
+                        </svg>
+                        <% end %>
+                        <% end %>
                       </div>
                       <% rescue => e %>
                       <div class="text-xs text-red-500">データエラー: <%= e.message %></div>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -1,12 +1,13 @@
 <!-- app/views/recipes/show.html.erb -->
 <% set_meta_tags recipe_meta_tags(@calendar_plans) %>
 
-<div class="container mx-auto my-12 px-4">
+<div class="container mx-auto my-12 px-6 sm:px-8 md:px-12 lg:px-16">
   <!-- ページタイトル -->
   <h1 class="text-3xl font-bold text-center mb-6">選択された献立</h1>
 
   <!-- ボタンエリア -->
-  <div class="flex justify-center space-x-4 mb-8">
+  <div class="flex flex-wrap justify-center gap-4 mb-8">
+    <% unless params[:from_calendar] %>
     <%= button_to new_recipe_path,
         method: :get,
         class: "inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-orange-600 rounded-lg hover:bg-orange-700 transition-colors" do %>
@@ -16,7 +17,12 @@
     この献立を作成
     <% end %>
 
-    <%= link_to recipe_path(id: params[:id], cancel: true),
+    <%= link_to recipe_path(
+      id: params[:id], 
+      cancel: true, 
+      meal_time: @calendar_plans.first&.meal_time,
+      generated_at: @calendar_plans.first&.created_at&.iso8601
+    ),
     class: "inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors",
     data: { 
       turbo_method: :get,
@@ -44,6 +50,15 @@
     </svg>
     もう一度献立作成
     <% end %>
+    <% else %>
+    <%= link_to new_recipe_path,
+      class: "inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors" do %>
+    <svg class="w-5 h-5 mr-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path d="M19 12H5M12 19l-7-7 7-7" />
+    </svg>
+    戻る
+    <% end %>
+    <% end %>
 
     <% if @share_text.present? %>
     <%= link_to "https://twitter.com/intent/tweet?text=#{@share_text}&url=#{@share_url}",
@@ -55,70 +70,124 @@
     </svg>
     Xへ投稿
     <% end %>
-    <% end %>
   </div>
-  <% if @calendar_plans.present? %>
-  <% time_mapping = { 
-                      "morning" => "朝", "afternoon" => "昼", "evening" => "夜",
-                      "0" => "朝", "1" => "昼", "2" => "夜", 
-                      0 => "朝", 1 => "昼", 2 => "夜"
-                    } %>
-  <% @calendar_plans.each do |calendar_plan| %>
-  <% if meal_plan = JSON.parse(calendar_plan.meal_plan, symbolize_names: true) rescue nil %>
-  <div class="mb-12 border border-gray-300 p-4 rounded-lg bg-white shadow-md">
-    <!-- 日付と時間帯の表示 -->
-    <h2 class="text-2xl font-bold mb-4">
-      日付: <%= calendar_plan.date.strftime('%Y年%m月%d日') %> /
-      時間帯: <%= calendar_plan.meal_time_text %>
+</div>
 
+<% if @calendar_plans.present? %>
+<!-- 日付ごとにグループ化 -->
+<% 
+    # 最新の献立の日付とmeal_timeを取得
+    newest_plans = []
+    if params[:all_dates].present?
+      newest_plans = @calendar_plans.select { |plan| plan.created_at > 1.minute.ago }
+    else
+      newest_plans = @calendar_plans.select { |plan| plan.created_at > 1.minute.ago }
+    end
+
+    @calendar_plans.group_by { |plan| plan.date }.each do |date, plans_for_date| 
+  %>
+<div class="mb-10 px-4 sm:px-6">
+  <!-- 日付ヘッダー -->
+  <h2 class="text-2xl font-bold mb-6 pb-2 border-b-2 border-orange-300">
+    <%= date.strftime('%Y年%m月%d日') %>
+  </h2>
+
+  <!-- この日付の献立をグリッド表示 -->
+  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+    <% plans_for_date.each do |calendar_plan| %>
+    <% if meal_plan = JSON.parse(calendar_plan.meal_plan, symbolize_names: true) rescue nil %>
+    <!-- 新しく作成された献立の場合はハイライト表示する -->
+    <% is_new_plan = newest_plans.any? { |p| p.id == calendar_plan.id } && !params[:from_calendar] %>
+    <div class="border <%= is_new_plan ? 'border-orange-500 ring-2 ring-orange-300' : 'border-gray-300' %> p-5 sm:p-6 rounded-lg bg-white shadow-md">
+      <!-- 時間帯の表示 -->
+      <h3 class="text-xl font-bold mb-4 <%= is_new_plan ? 'text-orange-600' : 'text-gray-800' %>">
+        <%= calendar_plan.meal_time_text %>
+        <% if is_new_plan %>
+        <span class="ml-2 px-2 py-0.5 text-xs bg-orange-100 text-orange-800 rounded-full">新規作成</span>
+        <% end %>
+      </h3>
 
       <!-- 献立内容 -->
-      <div class="mb-6">
-        <h3 class="text-xl font-bold mb-2">献立の内容</h3>
+      <div class="mb-4">
+        <h4 class="text-lg font-semibold mb-2">献立の内容</h4>
         <ul class="list-disc list-inside">
           <li>主菜: <%= meal_plan[:main] || "データなし" %></li>
           <li>副菜: <%= meal_plan[:side] || "データなし" %></li>
         </ul>
       </div>
 
-      <!-- 栄養素情報セクション内 -->
-      <div class="mb-6 bg-blue-50 p-4 rounded-lg">
-        <h3 class="text-xl font-bold text-blue-700 mb-2">栄養素情報</h3>
-        <% if @parsed_meal_plans.present? && @parsed_meal_plans.first[:chart_data].present? %>
-        <div class="mb-6">
-          <div style="width: 400px; height: 400px;" class="mx-auto">
-            <canvas data-controller="nutrition-chart" data-nutrition-chart-data="<%= @parsed_meal_plans.first[:chart_data].to_json %>" width="400" height="400">
-            </canvas>
-          </div>
-
-          <ul class="list-disc list-inside mt-4">
-            <li>タンパク質: <%= @parsed_meal_plans.first.dig(:nutrients, :protein) || "データなし" %></li>
-            <li>脂質: <%= @parsed_meal_plans.first.dig(:nutrients, :fat) || "データなし" %></li>
-            <li>炭水化物: <%= @parsed_meal_plans.first.dig(:nutrients, :carbohydrates) || "データなし" %></li>
-            <li>ビタミン: <%= @parsed_meal_plans.first.dig(:nutrients, :vitamins)&.join(", ") || "データなし" %></li>
-            <li>ミネラル: <%= @parsed_meal_plans.first.dig(:nutrients, :minerals)&.join(", ") || "データなし" %></li>
-          </ul>
-          <% end %>
+      <!-- 栄養素情報とチャート -->
+      <div class="mb-4 bg-blue-50 p-3 rounded-lg">
+        <h4 class="text-md font-semibold text-blue-700 mb-2">栄養素情報</h4>
+        <% 
+            parsed_meal_plan_index = @parsed_meal_plans.index { |p| p[:main] == meal_plan[:main] && p[:side] == meal_plan[:side] }
+            parsed_meal_plan = parsed_meal_plan_index ? @parsed_meal_plans[parsed_meal_plan_index] : nil
+          %>
+        <% if parsed_meal_plan && parsed_meal_plan[:chart_data].present? %>
+        <!-- チャート -->
+        <div style="width: 280px; height: 280px;" class="mx-auto mb-3">
+          <canvas data-controller="nutrition-chart" data-nutrition-chart-data="<%= parsed_meal_plan[:chart_data].to_json %>" width="280" height="280">
+          </canvas>
         </div>
 
-        <!-- 使用した食材 -->
-        <div>
-          <h3 class="text-xl font-bold mb-2">使用した食材</h3>
-          <% if meal_plan[:ingredients].present? %>
-          <ul class="list-disc list-inside">
-            <% meal_plan[:ingredients].each do |ingredient| %>
-            <li><%= ingredient %></li>
-            <% end %>
-          </ul>
-          <% else %>
-          <p class="text-gray-500">食材情報がありません。</p>
-          <% end %>
-        </div>
+        <ul class="list-disc list-inside text-sm mt-3">
+          <li>タンパク質: <%= parsed_meal_plan.dig(:nutrients, :protein) || "データなし" %></li>
+          <li>脂質: <%= parsed_meal_plan.dig(:nutrients, :fat) || "データなし" %></li>
+          <li>炭水化物: <%= parsed_meal_plan.dig(:nutrients, :carbohydrates) || "データなし" %></li>
+          <li>ビタミン: <%= Array(parsed_meal_plan.dig(:nutrients, :vitamins)).join(", ") %></li>
+          <li>ミネラル: <%= Array(parsed_meal_plan.dig(:nutrients, :minerals)).join(", ") %></li>
+        </ul>
+        <% else %>
+        <p class="text-gray-500 text-sm">栄養情報がありません</p>
+        <% end %>
       </div>
-      <% end %>
-      <% end %>
-      <% else %>
-      <p class="text-gray-500 text-center">献立データがありません。</p>
-      <% end %>
+
+      <!-- 使用した食材 -->
+      <div>
+        <h4 class="text-md font-semibold mb-2">使用した食材</h4>
+        <% if meal_plan[:ingredients].present? %>
+        <ul class="list-disc list-inside text-sm">
+          <% 
+              # 食材データが特殊な形式の場合は正しく表示する
+              if meal_plan[:ingredients].is_a?(Hash) && meal_plan[:ingredients][:main_dish]
+                # 構造化された食材データの場合
+            %>
+          <% if meal_plan[:ingredients][:main_dish].present? %>
+          <li class="font-medium mt-1">主菜:</li>
+          <% meal_plan[:ingredients][:main_dish].each do |ingredient| %>
+          <% ingredient.each do |item, amount| %>
+          <li class="ml-4"><%= item %>: <%= amount %></li>
+          <% end %>
+          <% end %>
+          <% end %>
+
+          <% if meal_plan[:ingredients][:side_dish].present? %>
+          <li class="font-medium mt-1">副菜:</li>
+          <% meal_plan[:ingredients][:side_dish].each do |ingredient| %>
+          <% ingredient.each do |item, amount| %>
+          <li class="ml-4"><%= item %>: <%= amount %></li>
+          <% end %>
+          <% end %>
+          <% end %>
+          <% else %>
+          <!-- 通常の食材リスト -->
+          <% meal_plan[:ingredients].each do |ingredient| %>
+          <li><%= ingredient %></li>
+          <% end %>
+          <% end %>
+        </ul>
+        <% else %>
+        <p class="text-gray-500 text-sm">食材情報がありません</p>
+        <% end %>
+      </div>
+    </div>
+    <% end %>
+    <% end %>
   </div>
+</div>
+<% end %>
+<% end %>
+<% else %>
+<p class="text-gray-500 text-center">献立データがありません。</p>
+<% end %>
 </div>


### PR DESCRIPTION
## 概要
このプルリクエストでは、特定の日付や時間帯のみを保存せずに戻る機能を修正しました。これにより、既存の献立が削除されることなく、選択した日付や時間帯のみを保存せずに戻ることができます。

## 修正内容
- `show.html.erb`ファイルにおいて、「生成せずに戻る」ボタンを押した際に、特定の日付や時間帯のみを保存せずに戻るように修正しました。
- `new.html.erb`から遷移した場合にハイライトが表示されないように修正しました。

## 修正ファイル
- `app/views/recipes/show.html.erb`

## 詳細
### `show.html.erb`の修正
`params[:from_calendar]`を使用して条件分岐を追加し、特定の日付や時間帯のみを保存せずに戻るように修正しました。
